### PR TITLE
Fix AbstractPicture.get_size for portrait images

### DIFF
--- a/djangocms_picture/models.py
+++ b/djangocms_picture/models.py
@@ -254,15 +254,24 @@ class AbstractPicture(CMSPlugin):
             width = self.width
             height = self.height
 
-        # calculate height when not given according to the
-        # golden ratio or fallback to the picture size
-        if not height and width:
-            height = int(width / PICTURE_RATIO)
-        elif not width and height:
-            width = int(height * PICTURE_RATIO)
-        elif not width and not height and self.picture:
-            width = self.picture.width
-            height = self.picture.height
+        if self.picture:
+            # calculate height when not given according to the
+            # golden ratio or fallback to the picture size
+            if crop:
+                if not height and width:
+                    if self.picture.width > self.picture.height:
+                        height = int(width / PICTURE_RATIO)
+                    else:
+                        height = int(width * PICTURE_RATIO)
+
+                elif not width and height:
+                    if self.picture.width > self.picture.height:
+                        width = int(height * PICTURE_RATIO)
+                    else:
+                        width = int(height / PICTURE_RATIO)
+
+            width = width or self.picture.width
+            height = height or self.picture.height
 
         options = {
             'size': (width, height),


### PR DESCRIPTION
We input a 1:2 image and set JUST a width limit. The output was a tiny image stretched to our original limit. and was getting out a bizarrely tiny image. This was due to two problems.
 - Only involve the Golden Ratio when you're cropping! This is applied to all scaling operations currently, and probably "works" because people don't notice it on nearer-square images.
 - Use it in the right direction. When you have a portrait image, you need to inverse the ratio.

This patch has been tested on our ~150 page CMS but I wouldn't for a second believe we use every feature of this plugin.