### PR TITLE
Apply {% localize off %} on <img> element

### DIFF
--- a/djangocms_picture/templates/djangocms_picture/default/picture.html
+++ b/djangocms_picture/templates/djangocms_picture/default/picture.html
@@ -1,4 +1,4 @@
-{% load thumbnail %}
+{% load thumbnail l10n %}
 
 {% if picture_link %}
     <a href="{{ picture_link }}"
@@ -13,6 +13,7 @@
 {# end render figure/figcaption #}
 
 
+{% localize off %}
 <img src="{{ instance.img_src }}"
     alt="{% if instance.attributes.alt %}{{ instance.attributes.alt }}{% elif instance.picture.default_alt_text %}{{ instance.picture.default_alt_text }}{% endif %}"
     {% if instance.width %} width="{{ instance.width }}"{% endif %}
@@ -33,6 +34,7 @@
     {% endif %}
     {{ instance.attributes_str }}
 >
+{% endlocalize %}
 
 {# start render figure/figcaption #}
 {% if instance.caption_text %}


### PR DESCRIPTION
## Description

At least {{ picture_size.size.0 }}px in line 32 of the template picture.html
can have a decimal comma in some cases which causes the image not to be
displayed in Firefox 95.0b8 and Chrome 96.0.4664.45.

## Checklist

<!--
Please check the following items before submitting, otherwise,
your pull request will be closed.
Use 'x' to check each item: [x] I have ...
-->

* [x] I have opened this pull request against ``master``
* [ ] I have added or modified the tests when changing logic
* [ ] I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog
* [ ] I have read the [contribution guidelines ](https://github.com/django-cms/django-cms/blob/develop/CONTRIBUTING.rst) and I have joined #workgroup-pr-review on 
[Slack](https://www.django-cms.org/slack) to find a “pr review buddy” who is going to review my pull request.
