### PR TITLE
fix: Remove reference to `__latest__` migration of cms

### DIFF
--- a/djangocms_picture/migrations/0012_alter_picture_cmsplugin_ptr.py
+++ b/djangocms_picture/migrations/0012_alter_picture_cmsplugin_ptr.py
@@ -7,7 +7,7 @@ import django.db.models.deletion
 class Migration(migrations.Migration):
 
     dependencies = [
-        ('cms', '__latest__' ),
+        ('cms', '__first__' ),
         ('djangocms_picture', '0011_auto_20190314_1536'),
     ]
 


### PR DESCRIPTION
## Description

from Slack conversation:

> Vašek Chalupníček:
> Hi, anyone familiar with this problem?
> django.db.migrations.exceptions.InconsistentMigrationHistory: Migration djangocms_picture.0012_alter_picture_cmsplugin_ptr is applied before its dependency cms.0035_auto_20230822_2208 on database 'default'.
> I hit this when I update djangocms v4 rc3 to rc4, it seems it originates from the fact that djangocms_picture.0012 has __latest__ as it's dependency and after updating python code it resolves to cms.0035 which has not been applied yet.
> I've resolved this by deleting djangocms_picture.0012 from django_migrations table (luckily this migration only contains label changes) - but it's stressful doing in production.
> It seems to me that this may occur every time the cms update contains migrations.
> 


> Fabian Braun:
> I think this is worth a PR to djangocms-picture. If it's only label changes it could refer to __first__ instead of __latest__  safely. Would you be interested in fixing this?
> (It turns out having __latest__as a reference in migrations is a bad thing.)
> 